### PR TITLE
Fix updateUser test

### DIFF
--- a/test/intercom_flutter_test.dart
+++ b/test/intercom_flutter_test.dart
@@ -80,6 +80,7 @@ void main() {
         'phone': '+37256123456',
         'company': 'Some Company LLC',
         'companyId': '2',
+        'customAttributes': null
       });
     });
   });


### PR DESCRIPTION
Running the updateUser test will fail without expecting a null customAttributes.

Output:
```
package:test_api                                   expect
package:flutter_test/src/widget_tester.dart 166:3  expect
test/test_method_channel.dart 47:3                 expectMethodCall
test/intercom_flutter_test.dart 77:7               main.<fn>.<fn>

Expected: has method name: 'updateUser' with arguments: {
            'email': 'test@example.com',
            'name': 'John Doe',
            'userId': '1',
            'phone': '+37256123456',
            'company': 'Some Company LLC',
            'companyId': '2'
          }
  Actual: MethodCall:<MethodCall(updateUser, {email: test@example.com, name: John Doe, phone: +37256123456, company: Some Company LLC, companyId: 2, userId: 1, customAttributes: null})>
```