### PR TITLE
Pub.dev url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intercom_flutter
 
-[![Pub](https://img.shields.io/badge/Pub-2.0.3-orange.svg)](https://pub.dartlang.org/packages/intercom_flutter)
+[![Pub](https://img.shields.io/badge/Pub-2.0.3-orange.svg)](https://pub.dev/packages/intercom_flutter)
 [![Codemagic build status](https://api.codemagic.io/apps/5cef7aa5a415930008ecf27b/5cef7aa5a415930008ecf27a/status_badge.svg)](https://codemagic.io/apps/5cef7aa5a415930008ecf27b/5cef7aa5a415930008ecf27a/latest_build)
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android) and [iOS](https://github.com/intercom/intercom-ios) projects.


### PR DESCRIPTION
Changes [pub.dartlang.org](https://pub.dartlang.org/) to the new [pub.dev](https://pub.dev/) in `README.md`,