### PR TITLE
#55 - migrate to flutter v2 embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+* Migrate Android side to Flutter's v2 Android Plugin APIs
+
 ## 2.2.1
 * Implement sendTokenToIntercom method on iOS side to support push notifications
 

--- a/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -25,9 +25,9 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
     fun registerWith(registrar: Registrar) {
       val channel = MethodChannel(registrar.messenger(), "maido.io/intercom")
       application = registrar.context() as Application
-      channel.setMethodCallHandler(IntercomFlutterPlugin()
+      channel.setMethodCallHandler(IntercomFlutterPlugin())
       val unreadEventChannel = EventChannel(registrar.messenger(), "maido.io/intercom/unread")
-      unreadEventChannel.setStreamHandler(IntercomFlutterPlugin()
+      unreadEventChannel.setStreamHandler(IntercomFlutterPlugin())
     }
   }
 
@@ -36,16 +36,16 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     val channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "maido.io/intercom")
-    channel.setMethodCallHandler(IntercomFlutterPlugin()
+    channel.setMethodCallHandler(IntercomFlutterPlugin())
     val unreadEventChannel = EventChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "maido.io/intercom/unread")
-    unreadEventChannel.setStreamHandler(IntercomFlutterPlugin()
+    unreadEventChannel.setStreamHandler(IntercomFlutterPlugin())
   }
 
   // https://stackoverflow.com/a/62206235
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    application = binding.activity.getApplication();
+    application = binding.activity.getApplication()
   }
-  
+
   override fun onMethodCall(call: MethodCall, result: Result) {
     when {
       call.method == "initialize" -> {
@@ -203,11 +203,11 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
   override fun onCancel(arguments: Any?) {
     Intercom.client().removeUnreadConversationCountListener(unreadConversationCountListener)
   }
-  
+
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     Intercom.client().removeUnreadConversationCountListener(unreadConversationCountListener)
   }
-  
+
   override fun onDetachedFromActivity() {
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 2.2.1
+version: 2.3.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
Ay, thanks for this plugin. It's been super useful. The team @ Greenbits has been making use of this plugin and we noticed there was an open issue for upgrading to Android embedding.

I haven't seen the `registrar.context() as Application` invocation before, but if it's equivalent to `registrar.activity().getApplication()`, then it's all the same.

** I don't have access to an Android device and would really appreciate someone running this on a physical device **