### PR TITLE
Resolution strategy - build fail

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,4 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'io.intercom.android:intercom-sdk:7.2.+'
+    implementation 'androidx.collection:collection:1.1.0'
 }


### PR DESCRIPTION
Dependency resolution fails as multiple dependencies require different versions of androidx.collection:collection:1.1.0 or androidx.collection:collection:1.0.0