### PR TITLE
Prevents sending empty tokens to intercom

### DIFF
--- a/lib/intercom_flutter.dart
+++ b/lib/intercom_flutter.dart
@@ -119,6 +119,13 @@ class Intercom {
   }
 
   static Future<dynamic> sendTokenToIntercom(String token) {
+    assert(token?.isNotEmpty == true);
+
+    // empty token let the app crash, so prevent before invoking method
+    if (token?.isNotEmpty == false) {
+      throw 'Push token must not be empty.';
+    }
+
     print("Start sending token to Intercom");
     return _channel.invokeMethod('sendTokenToIntercom', {'token': token});
   }


### PR DESCRIPTION
Referring to issue #102 it's very dangerous that the app fully crashes if the token is nil. I was not able to reproduce, why `getToken()` of Firebase Messaging plugin returns null but when callng `Intercom.sendTokenToIntercom(null)` I was able to reproduce the crash. 

So I suggest adding any check which prevents sending non strings to the native handler. While we are working with dynamic return type, I added an exception. I could also imagine to work with boolean return type while I now preferred not changing the function's signature.