### PR TITLE
[bugfix] Fix #112 App is crashing on iOS if token provided is null

### DIFF
--- a/ios/Classes/IntercomFlutterPlugin.m
+++ b/ios/Classes/IntercomFlutterPlugin.m
@@ -113,9 +113,11 @@ id unread;
         [Intercom presentMessageComposer:message];
     } else if([@"sendTokenToIntercom" isEqualToString:call.method]){
         NSString *token = call.arguments[@"token"];
-        NSData* encodedToken=[token dataUsingEncoding:NSUTF8StringEncoding];
-        [Intercom setDeviceToken:encodedToken];
-        result(@"Token set");
+        if(token != (id)[NSNull null] && token != nil) {
+            NSData* encodedToken=[token dataUsingEncoding:NSUTF8StringEncoding];
+            [Intercom setDeviceToken:encodedToken];
+            result(@"Token set");
+        }
     }
     else {
         result(FlutterMethodNotImplemented);

--- a/lib/intercom_flutter.dart
+++ b/lib/intercom_flutter.dart
@@ -121,7 +121,9 @@ class Intercom {
   }
 
   static Future<dynamic> sendTokenToIntercom(String token) {
-    print("Start sending token to Intercom");
+    if (token != null && token.isNotEmpty) {
+      print("Start sending token to Intercom");
+    }
     return _channel.invokeMethod('sendTokenToIntercom', {'token': token});
   }
 

--- a/lib/intercom_flutter.dart
+++ b/lib/intercom_flutter.dart
@@ -121,9 +121,8 @@ class Intercom {
   }
 
   static Future<dynamic> sendTokenToIntercom(String token) {
-    if (token != null && token.isNotEmpty) {
-      print("Start sending token to Intercom");
-    }
+    assert(token != null && token.isNotEmpty);
+    print("Start sending token to Intercom");
     return _channel.invokeMethod('sendTokenToIntercom', {'token': token});
   }
 


### PR DESCRIPTION
## Description

When `token` provided is null, app crashes in iOS.

## Tickets

- Closes #112

## Test Plan

### Steps to Replicate

1. Using the example app, add method call and send token as `null`
```
class SampleApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    Intercom.sendTokenToIntercom(null); // Add this
    return MaterialApp(
       ....
    );
  }
}
```

2. Run the app

### Expected State

App should not crash. It should swallow the error just like the other method calls in the class.
