### PR TITLE
Update Flutter constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,4 +24,4 @@ flutter:
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.12.13+hotfix.7 <2.0.0"
+  flutter: ">=2.0.0"


### PR DESCRIPTION
Version 3.0.0 can't be published to pub.dev as of now since Dart and Flutter constraints are not compatible