### PR TITLE
[android] Set application in onAttachedToEngine

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+* Fix `application has not been initialized` crash on Android when calling from background isolate.
+
 ## 3.2.0
 * Migrate to use intercom_flutter_platform_interface
 

--- a/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -40,6 +40,7 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
     channel.setMethodCallHandler(IntercomFlutterPlugin())
     val unreadEventChannel = EventChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "maido.io/intercom/unread")
     unreadEventChannel.setStreamHandler(IntercomFlutterPlugin())
+    application = flutterPluginBinding.applicationContext as Application
   }
 
   // https://stackoverflow.com/a/62206235

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
This avoids a crash of `application` being uninitialized when calling `Intercom.handlePush` from a Firebase Messaging background handler in a spawned isolate.

See:
https://firebase.flutter.dev/docs/messaging/usage#background-messages

Tested on Android 11 with a Samsung Galaxy A40 which crashes without this fix when receiving a push after being terminated.