### PR TITLE
Update not needed public constructor

### DIFF
--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -9,6 +9,9 @@ export 'package:intercom_flutter_platform_interface/intercom_flutter_platform_in
     show IntercomVisibility;
 
 class Intercom {
+    
+  Intercom._();
+    
   static Future<void> initialize(
     String appId, {
     String? androidApiKey,


### PR DESCRIPTION
The class Intercom serves its purpose mainly as a interface for static functions, so there's no need for the public constructor to be public, so we will make it private.