### PR TITLE
Issue 181

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.1.0+1
+* resolved issue [#181](https://github.com/v3rm0n/intercom_flutter/issues/181)
+
 ## 5.1.0
 * Bump Intercom Android SDK version to 10.4.0 ([#178](https://github.com/v3rm0n/intercom_flutter/pull/178))
 * Bump Intercom iOS SDK version to 10.3.0 ([#178](https://github.com/v3rm0n/intercom_flutter/pull/178))

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -42,4 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'io.intercom.android:intercom-sdk:10.4.0'
+    implementation 'com.google.firebase:firebase-messaging:23.0.0'
 }

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 5.1.0
+version: 5.1.0+1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
resolves https://github.com/v3rm0n/intercom_flutter/issues/181

Starting Android Intercom SDK [10.1.1 ](https://github.com/intercom/intercom-android/blob/master/CHANGELOG.md#version-1011), need to explicitly add the `firebase_messaging` dependency in build.gradle.