### PR TITLE
Update native sdk

### DIFF
--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -3,8 +3,13 @@
 [![Pub](https://img.shields.io/pub/v/intercom_flutter.svg)](https://pub.dev/packages/intercom_flutter)
 ![CI](https://github.com/v3rm0n/intercom_flutter/workflows/CI/badge.svg)
 
-Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android) and [iOS](https://github.com/intercom/intercom-ios) projects.  
-Now it also supports [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript).
+Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
+
+- Uses Intercom Android SDK Version `10.6.1`.
+- The minimum Android SDK `minSdkVersion` required is 21.
+- Uses Intercom iOS SDK Version `11.0.1`.
+- The minimum iOS target version required is 13.
+
 
 ## Usage
 

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:10.6.0'
+    implementation 'io.intercom.android:intercom-sdk:10.6.1'
     implementation 'com.google.firebase:firebase-messaging:23.0.0'
 }

--- a/intercom_flutter/example/ios/Podfile
+++ b/intercom_flutter/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -18,6 +18,6 @@ A new flutter plugin project.
   s.dependency 'Intercom'
   s.static_framework = true
   s.dependency 'Intercom', '~> 11.0.1'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 end
 

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '~> 10.4.0'
+  s.dependency 'Intercom', '~> 11.0.1'
   s.ios.deployment_target = '10.0'
 end
 


### PR DESCRIPTION
**updated Intercom Android SDK version to 10.6.1**
- fixes https://github.com/v3rm0n/intercom_flutter/issues/151.

**updated Intercom iOS SDK version to 11.0.1**
- `Breaking Change:` Intercom iOS SDK version 11.0.0 requires iOS minimum deployment target version 13. https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md#1100