### PR TITLE
Update intercom_flutter.podspec

### DIFF
--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '~> 11.0.1'
+  s.dependency 'Intercom', '~> 11.2.0'
   s.ios.deployment_target = '13.0'
 end
 


### PR DESCRIPTION
What I do and Why ?
- Update intercom_flutter/ios/intercom_flutter.podspec to lastest version.
- Current version is 11.0.1 and lastest version is 11.2.0, and there are some fixes in the releases version.
- Support link: https://github.com/intercom/intercom-ios/releases