### PR TITLE
Use Instance approach

### DIFF
--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -25,7 +25,7 @@ void main() async {
     WidgetsFlutterBinding.ensureInitialized();
     // initialize the Intercom.
     // make sure to add keys from your Intercom workspace.
-    await Intercom.initialize('appIdHere', iosApiKey: 'iosKeyHere', androidApiKey: 'androidKeyHere');
+    await Intercom.instance.initialize('appIdHere', iosApiKey: 'iosKeyHere', androidApiKey: 'androidKeyHere');
     runApp(App());
 }
 
@@ -38,7 +38,7 @@ class App extends StatelessWidget {
             onPressed: () async {
                 // messenger will load the messages only if the user is registered in Intercom.
                 // either identified or unidentified.
-                await Intercom.displayMessenger();
+                await Intercom.instance.displayMessenger();
             },
         );
     }
@@ -84,7 +84,7 @@ This plugin works in combination with the [`firebase_messaging`](https://pub.dev
 final firebaseMessaging = FirebaseMessaging.instance;
 final intercomToken = Platform.isIOS ? await firebaseMessaging.getAPNSToken() : await firebaseMessaging.getToken();
 
-Intercom.sendTokenToIntercom(intercomToken);
+Intercom.instance.sendTokenToIntercom(intercomToken);
 ```
 
 Now, if either Firebase direct (e.g. by your own backend server) or Intercom sends you a message, it will be delivered to your app.

--- a/intercom_flutter/example/lib/main.dart
+++ b/intercom_flutter/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:intercom_flutter/intercom_flutter.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Intercom.initialize(
+  await Intercom.instance.initialize(
     'appId',
     androidApiKey: 'androidApiKey',
     iosApiKey: 'iosApiKey',
@@ -22,7 +22,7 @@ class SampleApp extends StatelessWidget {
         body: Center(
           child: TextButton(
             onPressed: () {
-              Intercom.displayMessenger();
+              Intercom.instance.displayMessenger();
             },
             child: Text('Show messenger'),
           ),

--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -9,7 +9,13 @@ export 'package:intercom_flutter_platform_interface/intercom_flutter_platform_in
     show IntercomVisibility;
 
 class Intercom {
+  /// private constructor to not allow the object creation from outside.
   Intercom._();
+
+  static final Intercom _instance = Intercom._();
+
+  /// get the instance of the [Intercom].
+  static Intercom get instance => _instance;
 
   /// Function to initialize the Intercom SDK.
   ///
@@ -22,7 +28,7 @@ class Intercom {
   /// * [iOS](https://app.intercom.com/a/apps/_/settings/ios)
   ///
   /// Then, initialize Intercom in main method.
-  static Future<void> initialize(
+  Future<void> initialize(
     String appId, {
     String? androidApiKey,
     String? iosApiKey,
@@ -35,7 +41,7 @@ class Intercom {
   /// even if a user dismisses a notification.
   ///
   /// You can listen for unread conversation count with this method.
-  static Stream<dynamic> getUnreadStream() {
+  Stream<dynamic> getUnreadStream() {
     return IntercomFlutterPlatform.instance.getUnreadStream();
   }
 
@@ -43,7 +49,7 @@ class Intercom {
   ///
   /// It is useful if your app has a tab bar or similar UI at the bottom of your window.
   /// [padding] is the size of the bottom padding in points.
-  static Future<void> setBottomPadding(int padding) {
+  Future<void> setBottomPadding(int padding) {
     return IntercomFlutterPlatform.instance.setBottomPadding(padding);
   }
 
@@ -60,7 +66,7 @@ class Intercom {
   /// <https://gist.github.com/thewheat/7342c76ade46e7322c3e>
   ///
   /// Note: identity verification does not apply to unidentified users.
-  static Future<void> setUserHash(String userHash) {
+  Future<void> setUserHash(String userHash) {
     return IntercomFlutterPlatform.instance.setUserHash(userHash);
   }
 
@@ -70,7 +76,7 @@ class Intercom {
   ///
   /// You can register a identified user either with [userId] or with [email],
   /// but not with both.
-  static Future<void> registerIdentifiedUser({String? userId, String? email}) {
+  Future<void> registerIdentifiedUser({String? userId, String? email}) {
     return IntercomFlutterPlatform.instance
         .registerIdentifiedUser(userId: userId, email: email);
   }
@@ -78,7 +84,7 @@ class Intercom {
   /// Function to create a unidentified user in Intercom.
   /// You need to register your users before you can talk to them and
   /// track their activity in your app.
-  static Future<void> registerUnidentifiedUser() {
+  Future<void> registerUnidentifiedUser() {
     return IntercomFlutterPlatform.instance.registerUnidentifiedUser();
   }
 
@@ -92,7 +98,7 @@ class Intercom {
   ///
   /// See also:
   ///  * [Localize Intercom to work with multiple languages](https://www.intercom.com/help/en/articles/180-localize-intercom-to-work-with-multiple-languages)
-  static Future<void> updateUser({
+  Future<void> updateUser({
     String? email,
     String? name,
     String? phone,
@@ -118,12 +124,12 @@ class Intercom {
 
   /// To logout a user from Intercom.
   /// This clears the Intercom SDK's cache of your user's identity.
-  static Future<void> logout() {
+  Future<void> logout() {
     return IntercomFlutterPlatform.instance.logout();
   }
 
   /// To hide or show the standard launcher on the bottom right-hand side of the screen.
-  static Future<void> setLauncherVisibility(IntercomVisibility visibility) {
+  Future<void> setLauncherVisibility(IntercomVisibility visibility) {
     return IntercomFlutterPlatform.instance.setLauncherVisibility(visibility);
   }
 
@@ -131,13 +137,12 @@ class Intercom {
   /// even if a user dismisses a notification.
   ///
   /// You can get the current unread conversation count with this method.
-  static Future<int> unreadConversationCount() {
+  Future<int> unreadConversationCount() {
     return IntercomFlutterPlatform.instance.unreadConversationCount();
   }
 
   /// To allow or prevent in app messages from popping up in certain parts of your app.
-  static Future<void> setInAppMessagesVisibility(
-      IntercomVisibility visibility) {
+  Future<void> setInAppMessagesVisibility(IntercomVisibility visibility) {
     return IntercomFlutterPlatform.instance
         .setInAppMessagesVisibility(visibility);
   }
@@ -146,14 +151,14 @@ class Intercom {
   ///
   /// This is used when you manually want to launch Intercom messenger.
   /// for e.g: from your custom launcher (Help & Support) or (Talk to us).
-  static Future<void> displayMessenger() {
+  Future<void> displayMessenger() {
     return IntercomFlutterPlatform.instance.displayMessenger();
   }
 
   /// To close the Intercom messenger.
   ///
   /// This is used when you manually want to close Intercom messenger.
-  static Future<void> hideMessenger() {
+  Future<void> hideMessenger() {
     return IntercomFlutterPlatform.instance.hideMessenger();
   }
 
@@ -162,14 +167,14 @@ class Intercom {
   /// Make sure Help Center is turned on.
   /// If you don't have Help Center enabled in your Intercom settings the method
   /// displayHelpCenter will fail to load.
-  static Future<void> displayHelpCenter() {
+  Future<void> displayHelpCenter() {
     return IntercomFlutterPlatform.instance.displayHelpCenter();
   }
 
   /// To log events in Intercom that record what users do in your app and when they do it.
   /// For example, you can record when user opened a specific screen in your app.
   /// You can also pass [metaData] about the event.
-  static Future<void> logEvent(String name, [Map<String, dynamic>? metaData]) {
+  Future<void> logEvent(String name, [Map<String, dynamic>? metaData]) {
     return IntercomFlutterPlatform.instance.logEvent(name, metaData);
   }
 
@@ -177,7 +182,7 @@ class Intercom {
   ///
   /// For the Android, this [token] must be a FCM (Firebase cloud messaging) token.
   /// For the iOS, this [token] must be a APNS token.
-  static Future<void> sendTokenToIntercom(String token) {
+  Future<void> sendTokenToIntercom(String token) {
     return IntercomFlutterPlatform.instance.sendTokenToIntercom(token);
   }
 
@@ -185,26 +190,26 @@ class Intercom {
   /// such as the URI in your message or the conversation to open.
   ///
   /// When you want Intercom to act on that data, use this method.
-  static Future<void> handlePushMessage() {
+  Future<void> handlePushMessage() {
     return IntercomFlutterPlatform.instance.handlePushMessage();
   }
 
   /// To open the Intercom messenger to the composer screen with [message]
   /// field pre-populated.
-  static Future<void> displayMessageComposer(String message) {
+  Future<void> displayMessageComposer(String message) {
     return IntercomFlutterPlatform.instance.displayMessageComposer(message);
   }
 
   /// To check if the push [message] is for Intercom or not.
   /// This is useful when your app is also configured to receive push messages
   /// from third parties.
-  static Future<bool> isIntercomPush(Map<String, dynamic> message) async {
+  Future<bool> isIntercomPush(Map<String, dynamic> message) async {
     return IntercomFlutterPlatform.instance.isIntercomPush(message);
   }
 
   /// If the push [message] is for Intercom then use this method to let
   /// Intercom handle that push.
-  static Future<void> handlePush(Map<String, dynamic> message) async {
+  Future<void> handlePush(Map<String, dynamic> message) async {
     return IntercomFlutterPlatform.instance.handlePush(message);
   }
 
@@ -213,7 +218,7 @@ class Intercom {
   /// An article must be ‘live’ to be used in this feature.
   /// If it is in a draft or paused state,
   /// end-users will see an error if the app tries to open the content.
-  static Future<void> displayArticle(String articleId) async {
+  Future<void> displayArticle(String articleId) async {
     return IntercomFlutterPlatform.instance.displayArticle(articleId);
   }
 
@@ -222,7 +227,7 @@ class Intercom {
   /// A carousel must be ‘live’ to be used in this feature.
   /// If it is in a draft or paused state,
   /// end-users will see an error if the app tries to open the content.
-  static Future<void> displayCarousel(String carouselId) async {
+  Future<void> displayCarousel(String carouselId) async {
     return IntercomFlutterPlatform.instance.displayCarousel(carouselId);
   }
 }

--- a/intercom_flutter/test/intercom_flutter_test.dart
+++ b/intercom_flutter/test/intercom_flutter_test.dart
@@ -17,7 +17,7 @@ void main() {
       final androidApiKey = 'android-key';
       final iosApiKey = 'ios-key';
 
-      Intercom.initialize(
+      Intercom.instance.initialize(
         appId,
         androidApiKey: androidApiKey,
         iosApiKey: iosApiKey,
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('testSendingAPNTokenToIntercom', () {
-      Intercom.sendTokenToIntercom('mock_apn_token');
+      Intercom.instance.sendTokenToIntercom('mock_apn_token');
       expectMethodCall('sendTokenToIntercom', arguments: {
         'token': 'mock_apn_token',
       });
@@ -39,14 +39,14 @@ void main() {
 
     group('registerIdentifiedUser', () {
       test('with userId', () {
-        Intercom.registerIdentifiedUser(userId: 'test');
+        Intercom.instance.registerIdentifiedUser(userId: 'test');
         expectMethodCall('registerIdentifiedUserWithUserId', arguments: {
           'userId': 'test',
         });
       });
 
       test('with email', () {
-        Intercom.registerIdentifiedUser(email: 'test');
+        Intercom.instance.registerIdentifiedUser(email: 'test');
         expectMethodCall('registerIdentifiedUserWithEmail', arguments: {
           'email': 'test',
         });
@@ -54,7 +54,7 @@ void main() {
 
       test('with userId and email should fail', () {
         expect(
-          () => Intercom.registerIdentifiedUser(
+          () => Intercom.instance.registerIdentifiedUser(
             userId: 'testId',
             email: 'testEmail',
           ),
@@ -63,59 +63,60 @@ void main() {
       });
 
       test('without parameters', () {
-        expect(() => Intercom.registerIdentifiedUser(), throwsArgumentError);
+        expect(() => Intercom.instance.registerIdentifiedUser(),
+            throwsArgumentError);
       });
     });
 
     test('registerUnidentifiedUser', () {
-      Intercom.registerUnidentifiedUser();
+      Intercom.instance.registerUnidentifiedUser();
       expectMethodCall('registerUnidentifiedUser');
     });
 
     test('setBottomPadding', () {
       final padding = 64;
-      Intercom.setBottomPadding(padding);
+      Intercom.instance.setBottomPadding(padding);
       expectMethodCall('setBottomPadding', arguments: {
         'bottomPadding': padding,
       });
     });
 
     test('setUserHash', () {
-      Intercom.setUserHash('test');
+      Intercom.instance.setUserHash('test');
       expectMethodCall('setUserHash', arguments: {
         'userHash': 'test',
       });
     });
 
     test('logout', () {
-      Intercom.logout();
+      Intercom.instance.logout();
       expectMethodCall('logout');
     });
 
     group('toggleMessengerVisibility', () {
       test('displayMessenger', () {
-        Intercom.displayMessenger();
+        Intercom.instance.displayMessenger();
         expectMethodCall('displayMessenger');
       });
 
       test('hideMessenger', () {
-        Intercom.hideMessenger();
+        Intercom.instance.hideMessenger();
         expectMethodCall('hideMessenger');
       });
     });
 
     test('displayHelpCenter', () {
-      Intercom.displayHelpCenter();
+      Intercom.instance.displayHelpCenter();
       expectMethodCall('displayHelpCenter');
     });
 
     test('unreadConversationCount', () {
-      Intercom.unreadConversationCount();
+      Intercom.instance.unreadConversationCount();
       expectMethodCall('unreadConversationCount');
     });
 
     test('displayMessageComposer', () {
-      Intercom.displayMessageComposer("message");
+      Intercom.instance.displayMessageComposer("message");
       expectMethodCall(
         'displayMessageComposer',
         arguments: {"message": "message"},
@@ -124,14 +125,15 @@ void main() {
 
     group('setInAppMessagesVisibility', () {
       test('visible', () {
-        Intercom.setInAppMessagesVisibility(IntercomVisibility.visible);
+        Intercom.instance
+            .setInAppMessagesVisibility(IntercomVisibility.visible);
         expectMethodCall('setInAppMessagesVisibility', arguments: {
           'visibility': 'VISIBLE',
         });
       });
 
       test('gone', () {
-        Intercom.setInAppMessagesVisibility(IntercomVisibility.gone);
+        Intercom.instance.setInAppMessagesVisibility(IntercomVisibility.gone);
         expectMethodCall('setInAppMessagesVisibility', arguments: {
           'visibility': 'GONE',
         });
@@ -140,14 +142,14 @@ void main() {
 
     group('setLauncherVisibility', () {
       test('visible', () {
-        Intercom.setLauncherVisibility(IntercomVisibility.visible);
+        Intercom.instance.setLauncherVisibility(IntercomVisibility.visible);
         expectMethodCall('setLauncherVisibility', arguments: {
           'visibility': 'VISIBLE',
         });
       });
 
       test('gone', () {
-        Intercom.setLauncherVisibility(IntercomVisibility.gone);
+        Intercom.instance.setLauncherVisibility(IntercomVisibility.gone);
         expectMethodCall('setLauncherVisibility', arguments: {
           'visibility': 'GONE',
         });
@@ -155,7 +157,7 @@ void main() {
     });
 
     test('updateUser', () {
-      Intercom.updateUser(
+      Intercom.instance.updateUser(
         email: 'test@example.com',
         name: 'John Doe',
         userId: '1',
@@ -181,7 +183,7 @@ void main() {
 
   group('logEvent', () {
     test('withoutMetaData', () {
-      Intercom.logEvent("TEST");
+      Intercom.instance.logEvent("TEST");
       expectMethodCall('logEvent', arguments: {
         'name': 'TEST',
         'metaData': null,
@@ -189,7 +191,7 @@ void main() {
     });
 
     test('withMetaData', () {
-      Intercom.logEvent(
+      Intercom.instance.logEvent(
         "TEST",
         {'string': 'A string', 'number': 10, 'bool': true},
       );
@@ -220,13 +222,13 @@ void main() {
     });
 
     test('testStream', () async {
-      expect(await Intercom.getUnreadStream().first, value);
+      expect(await Intercom.instance.getUnreadStream().first, value);
     });
   });
 
   test('displayArticle', () async {
     final String testArticleId = "123456";
-    await Intercom.displayArticle(testArticleId);
+    await Intercom.instance.displayArticle(testArticleId);
     expectMethodCall('displayArticle', arguments: {
       'articleId': testArticleId,
     });
@@ -234,7 +236,7 @@ void main() {
 
   test('displayCarousel', () async {
     final String testCarouselId = "123456";
-    await Intercom.displayCarousel(testCarouselId);
+    await Intercom.instance.displayCarousel(testCarouselId);
     expectMethodCall('displayCarousel', arguments: {
       'carouselId': testCarouselId,
     });


### PR DESCRIPTION
fixes https://github.com/v3rm0n/intercom_flutter/issues/170

It is not possible to keep the static and instance members together with the same name (https://github.com/dart-lang/language/issues/1711) So the only solution is to delete the static methods and have only instance-level methods.

- version will be 7.0.0
- changelog will be updated according to the breaking change.