### PR TITLE
Status Callback support in platform interface

### DIFF
--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 # 1.1.0
 
-- added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
-- deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
-- added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
-- deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
-- added parameter `statusCallback` in `updateUser` to support `IntercomStatusCallback`.
-- renamed the following methods in the MethodChannel:
+- Added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
+- Deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
+- Added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
+- Deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
+- Added parameter `statusCallback` in `updateUser` to support `IntercomStatusCallback`.
+- Renamed the following methods in the MethodChannel:
     - `registerIdentifiedUserWithUserId` to `loginIdentifiedUserWithUserId`.
     - `regsiterIdentifiedUserWithEmail` to `loginIdentifiedUserWithEmail`.
     - `registerUnidentifiedUser` to `loginUnidentifiedUser`.
 
 # 1.0.1
 
-- added API documentation.
+- Added API documentation.
 
 # 1.0.0
 

--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# 1.1.0
+
+- added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
+- deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
+- added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
+- deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
+- added parameter `statusCallback` in `updateUser` to support `IntercomStatusCallback`.
+- renamed the following methods in the MethodChannel:
+    - `registerIdentifiedUserWithUserId` to `loginIdentifiedUserWithUserId`.
+    - `regsiterIdentifiedUserWithEmail` to `loginIdentifiedUserWithEmail`.
+    - `registerUnidentifiedUser` to `loginUnidentifiedUser`.
+
 # 1.0.1
 
 - added API documentation.

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -1,3 +1,4 @@
+import 'package:intercom_flutter_platform_interface/intercom_status_callback.dart';
 import 'package:intercom_flutter_platform_interface/method_channel_intercom_flutter.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -69,9 +70,21 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   ///
   /// You can register a identified user either with [userId] or with [email],
   /// but not with both.
+  @Deprecated("use loginIdentifiedUser")
   Future<void> registerIdentifiedUser({String? userId, String? email}) {
     throw UnimplementedError(
         'registerIdentifiedUser() has not been implemented.');
+  }
+
+  /// Function to create a identified user in Intercom.
+  /// You need to register your users before you can talk to them and
+  /// track their activity in your app.
+  ///
+  /// You can register a identified user either with [userId] or with [email],
+  /// but not with both.
+  Future<void> loginIdentifiedUser(
+      {String? userId, String? email, IntercomStatusCallback? statusCallback}) {
+    throw UnimplementedError('loginIdentifiedUser() has not been implemented.');
   }
 
   /// Function to create a unidentified user in Intercom.

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -124,6 +124,7 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
     int? signedUpAt,
     String? language,
     Map<String, dynamic>? customAttributes,
+    IntercomStatusCallback? statusCallback,
   }) {
     throw UnimplementedError('updateUser() has not been implemented.');
   }

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -90,9 +90,18 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   /// Function to create a unidentified user in Intercom.
   /// You need to register your users before you can talk to them and
   /// track their activity in your app.
+  @Deprecated("use loginUnidentifiedUser")
   Future<void> registerUnidentifiedUser() {
     throw UnimplementedError(
         'registerUnidentifiedUser() has not been implemented.');
+  }
+
+  /// Function to create a unidentified user in Intercom.
+  /// You need to register your users before you can talk to them and
+  /// track their activity in your app.
+  Future<void> loginUnidentifiedUser({IntercomStatusCallback? statusCallback}) {
+    throw UnimplementedError(
+        'loginUnidentifiedUser() has not been implemented.');
   }
 
   /// Updates the attributes of the current Intercom user.

--- a/intercom_flutter_platform_interface/lib/intercom_status_callback.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_status_callback.dart
@@ -1,0 +1,33 @@
+class IntercomStatusCallback {
+  /// callback when intercom operation is failed.
+  /// will contain the error information.
+  final Function(IntercomError error)? onFailure;
+
+  /// callback when intercom operation is success.
+  final Function()? onSuccess;
+
+  /// class for intercom status to check if the operation is success or failure.
+  /// if the operation failed then [onFailure] callback will be executed with
+  /// [IntercomError] details.
+  ///
+  IntercomStatusCallback({
+    this.onSuccess,
+    this.onFailure,
+  });
+}
+
+class IntercomError {
+  /// error code
+  final int errorCode;
+
+  /// error message
+  final String errorMessage;
+
+  /// class for the Intercom error data.
+  IntercomError(this.errorCode, this.errorMessage);
+
+  @override
+  String toString() {
+    return ("errorCode: $errorCode, errorMessage: $errorMessage");
+  }
+}

--- a/intercom_flutter_platform_interface/lib/intercom_status_callback.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_status_callback.dart
@@ -1,15 +1,14 @@
 class IntercomStatusCallback {
-  /// callback when intercom operation is failed.
-  /// will contain the error information.
+  /// Callback when intercom operation is failed.
+  /// It will contain the error information.
   final Function(IntercomError error)? onFailure;
 
-  /// callback when intercom operation is success.
+  /// Callback when intercom operation is success.
   final Function()? onSuccess;
 
-  /// class for intercom status to check if the operation is success or failure.
-  /// if the operation failed then [onFailure] callback will be executed with
+  /// Class for intercom status to check if the operation is success or failure.
+  /// If the operation failed then [onFailure] callback will be executed with
   /// [IntercomError] details.
-  ///
   IntercomStatusCallback({
     this.onSuccess,
     this.onFailure,
@@ -23,7 +22,7 @@ class IntercomError {
   /// error message
   final String errorMessage;
 
-  /// class for the Intercom error data.
+  /// Class for the Intercom error data.
   IntercomError(this.errorCode, this.errorMessage);
 
   @override

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -221,7 +221,7 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     await _channel.invokeMethod('displayCarousel', {'carouselId': carouselId});
   }
 
-  /// convert the [PlatformException] details to [IntercomError].
+  /// Convert the [PlatformException] details to [IntercomError].
   /// From the Platform side if the intercom operation failed then error details
   /// will be sent as details in [PlatformException].
   IntercomError _convertExceptionToIntercomError(PlatformException e) {

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -70,9 +70,21 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     }
   }
 
+  @Deprecated("use loginUnidentifiedUser")
   @override
-  Future<void> registerUnidentifiedUser() async {
-    await _channel.invokeMethod('registerUnidentifiedUser');
+  Future<void> registerUnidentifiedUser() {
+    return loginUnidentifiedUser();
+  }
+
+  @override
+  Future<void> loginUnidentifiedUser(
+      {IntercomStatusCallback? statusCallback}) async {
+    try {
+      await _channel.invokeMethod('registerUnidentifiedUser');
+      statusCallback?.onSuccess?.call();
+    } on PlatformException catch (e) {
+      statusCallback?.onFailure?.call(_convertExceptionToIntercomError(e));
+    }
   }
 
   @override

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -57,7 +57,7 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
       }
     } else if (email?.isNotEmpty ?? false) {
       try {
-        _channel.invokeMethod('loginIdentifiedUserWithEmail', {
+        await _channel.invokeMethod('loginIdentifiedUserWithEmail', {
           'email': email,
         });
         statusCallback?.onSuccess?.call();

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -48,7 +48,7 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
             'The parameter `email` must be null if `userId` is provided.');
       }
       try {
-        await _channel.invokeMethod('registerIdentifiedUserWithUserId', {
+        await _channel.invokeMethod('loginIdentifiedUserWithUserId', {
           'userId': userId,
         });
         statusCallback?.onSuccess?.call();
@@ -57,7 +57,7 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
       }
     } else if (email?.isNotEmpty ?? false) {
       try {
-        _channel.invokeMethod('registerIdentifiedUserWithEmail', {
+        _channel.invokeMethod('loginIdentifiedUserWithEmail', {
           'email': email,
         });
         statusCallback?.onSuccess?.call();
@@ -80,7 +80,7 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
   Future<void> loginUnidentifiedUser(
       {IntercomStatusCallback? statusCallback}) async {
     try {
-      await _channel.invokeMethod('registerUnidentifiedUser');
+      await _channel.invokeMethod('loginUnidentifiedUser');
       statusCallback?.onSuccess?.call();
     } on PlatformException catch (e) {
       statusCallback?.onFailure?.call(_convertExceptionToIntercomError(e));

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -98,18 +98,24 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     int? signedUpAt,
     String? language,
     Map<String, dynamic>? customAttributes,
+    IntercomStatusCallback? statusCallback,
   }) async {
-    await _channel.invokeMethod('updateUser', <String, dynamic>{
-      'email': email,
-      'name': name,
-      'phone': phone,
-      'company': company,
-      'companyId': companyId,
-      'userId': userId,
-      'signedUpAt': signedUpAt,
-      'language': language,
-      'customAttributes': customAttributes,
-    });
+    try {
+      await _channel.invokeMethod('updateUser', <String, dynamic>{
+        'email': email,
+        'name': name,
+        'phone': phone,
+        'company': company,
+        'companyId': companyId,
+        'userId': userId,
+        'signedUpAt': signedUpAt,
+        'language': language,
+        'customAttributes': customAttributes,
+      });
+      statusCallback?.onSuccess?.call();
+    } on PlatformException catch (e) {
+      statusCallback?.onFailure?.call(_convertExceptionToIntercomError(e));
+    }
   }
 
   @override

--- a/intercom_flutter_platform_interface/pubspec.yaml
+++ b/intercom_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_platform_interface
 description: A common platform interface for the intercom_flutter plugin.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
+++ b/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
@@ -83,13 +83,13 @@ void main() {
       );
     });
 
-    group('registerIdentifiedUser', () {
+    group('loginIdentifiedUser', () {
       test('with userId', () async {
-        await intercom.registerIdentifiedUser(userId: 'test');
+        await intercom.loginIdentifiedUser(userId: 'test');
         expect(
           log,
           <Matcher>[
-            isMethodCall('registerIdentifiedUserWithUserId', arguments: {
+            isMethodCall('loginIdentifiedUserWithUserId', arguments: {
               'userId': 'test',
             })
           ],
@@ -97,11 +97,11 @@ void main() {
       });
 
       test('with email', () async {
-        await intercom.registerIdentifiedUser(email: 'test');
+        await intercom.loginIdentifiedUser(email: 'test');
         expect(
           log,
           <Matcher>[
-            isMethodCall('registerIdentifiedUserWithEmail', arguments: {
+            isMethodCall('loginIdentifiedUserWithEmail', arguments: {
               'email': 'test',
             })
           ],
@@ -110,7 +110,7 @@ void main() {
 
       test('with userId and email should fail', () {
         expect(
-          () => intercom.registerIdentifiedUser(
+          () => intercom.loginIdentifiedUser(
             userId: 'testId',
             email: 'testEmail',
           ),
@@ -119,15 +119,15 @@ void main() {
       });
 
       test('without parameters', () {
-        expect(() => intercom.registerIdentifiedUser(), throwsArgumentError);
+        expect(() => intercom.loginIdentifiedUser(), throwsArgumentError);
       });
     });
 
-    test('registerUnidentifiedUser', () async {
-      await intercom.registerUnidentifiedUser();
+    test('loginUnidentifiedUser', () async {
+      await intercom.loginUnidentifiedUser();
       expect(
         log,
-        <Matcher>[isMethodCall('registerUnidentifiedUser', arguments: null)],
+        <Matcher>[isMethodCall('loginUnidentifiedUser', arguments: null)],
       );
     });
 


### PR DESCRIPTION
Android [v12.1.0](https://github.com/intercom/intercom-android/blob/master/CHANGELOG.md#1210)
iOS [v12.1.0](https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md#1210)

As Intercom SDK version 12.1.0, deprecated the following APIs:

- registerIdentifiedUser
- registerUnidentifiedUser

in favor of:

- loginIdentifiedUser with IntercomStatusCallback support
- loginUnidentifiedUser with IntercomStatusCallback support.

This also added IntercomStatusCallback support in updateUser API.

This PR will adopt such changes so that we can update the intercom_flutter package to use v12.1.0