### PR TITLE
Status callback support in web.

### DIFF
--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -78,14 +78,14 @@ class Intercom {
   /// but not with both.
   Future<void> registerIdentifiedUser({String? userId, String? email}) {
     return IntercomFlutterPlatform.instance
-        .registerIdentifiedUser(userId: userId, email: email);
+        .loginIdentifiedUser(userId: userId, email: email);
   }
 
   /// Function to create a unidentified user in Intercom.
   /// You need to register your users before you can talk to them and
   /// track their activity in your app.
   Future<void> registerUnidentifiedUser() {
-    return IntercomFlutterPlatform.instance.registerUnidentifiedUser();
+    return IntercomFlutterPlatform.instance.loginUnidentifiedUser();
   }
 
   /// Updates the attributes of the current Intercom user.

--- a/intercom_flutter/test/intercom_flutter_test.dart
+++ b/intercom_flutter/test/intercom_flutter_test.dart
@@ -40,14 +40,14 @@ void main() {
     group('registerIdentifiedUser', () {
       test('with userId', () {
         Intercom.instance.registerIdentifiedUser(userId: 'test');
-        expectMethodCall('registerIdentifiedUserWithUserId', arguments: {
+        expectMethodCall('loginIdentifiedUserWithUserId', arguments: {
           'userId': 'test',
         });
       });
 
       test('with email', () {
         Intercom.instance.registerIdentifiedUser(email: 'test');
-        expectMethodCall('registerIdentifiedUserWithEmail', arguments: {
+        expectMethodCall('loginIdentifiedUserWithEmail', arguments: {
           'email': 'test',
         });
       });
@@ -70,7 +70,7 @@ void main() {
 
     test('registerUnidentifiedUser', () {
       Intercom.instance.registerUnidentifiedUser();
-      expectMethodCall('registerUnidentifiedUser');
+      expectMethodCall('loginUnidentifiedUser');
     });
 
     test('setBottomPadding', () {

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 0.1.0
+
+- added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
+- deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
+- added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
+- deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
+- added parameter `statusCallback` in updateUser to support `IntercomStatusCallback`.
+- updated `intercom_flutter_platform_interface` version to `1.1.0`.
+
 # 0.0.5
 
 - implemented `displayArticle` [(showArticle)](https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid)

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -2,28 +2,28 @@
 
 # 0.1.0
 
-- added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
-- deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
-- added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
-- deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
-- added parameter `statusCallback` in updateUser to support `IntercomStatusCallback`.
-- updated `intercom_flutter_platform_interface` version to `1.1.0`.
+- Added method `loginIdentifiedUser` with `IntercomStatusCallback` support.
+- Deprecated `registerIdentifiedUser` in favor of `loginIdentifiedUser`.
+- Added method `loginUnidentifiedUser` with `IntercomStatusCallback` support.
+- Deprecated `registerUnidentifiedUser` in favor of `loginUnidentifiedUser`.
+- Added parameter `statusCallback` in updateUser to support `IntercomStatusCallback`.
+- Updated `intercom_flutter_platform_interface` version to `1.1.0`.
 
 # 0.0.5
 
-- implemented `displayArticle` [(showArticle)](https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid)
+- Implemented `displayArticle` [(showArticle)](https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid)
 
 # 0.0.4
 
-- updated dependency `intercom_flutter_platform_interface: ^1.0.1`
+- Updated dependency `intercom_flutter_platform_interface: ^1.0.1`
 
 # 0.0.3
 
-- resolved issue [#173](https://github.com/v3rm0n/intercom_flutter/issues/173)
+- Resolved issue [#173](https://github.com/v3rm0n/intercom_flutter/issues/173)
 
 # 0.0.2
 
-- updated dependency intercom_flutter_platform_interface: ^1.0.0
+- Updated dependency intercom_flutter_platform_interface: ^1.0.0
 
 # 0.0.1
 

--- a/intercom_flutter_web/example/integration_test/intercom_flutter_web_test.dart
+++ b/intercom_flutter_web/example/integration_test/intercom_flutter_web_test.dart
@@ -16,28 +16,27 @@ void main() {
       expect(plugin.initialize("mock"), completes);
     });
 
-    group('registerIdentifiedUser', () {
+    group('loginIdentifiedUser', () {
       testWidgets('with userId', (WidgetTester _) async {
-        expect(plugin.registerIdentifiedUser(userId: 'test'), completes);
+        expect(plugin.loginIdentifiedUser(userId: 'test'), completes);
       });
 
       testWidgets('with email', (WidgetTester _) async {
-        expect(plugin.registerIdentifiedUser(email: 'test'), completes);
+        expect(plugin.loginIdentifiedUser(email: 'test'), completes);
       });
 
       testWidgets('with userId and email should fail', (WidgetTester _) async {
-        expect(
-            plugin.registerIdentifiedUser(userId: 'testId', email: 'testEmail'),
+        expect(plugin.loginIdentifiedUser(userId: 'testId', email: 'testEmail'),
             throwsArgumentError);
       });
 
       testWidgets('without parameters', (WidgetTester _) async {
-        expect(plugin.registerIdentifiedUser(), throwsArgumentError);
+        expect(plugin.loginIdentifiedUser(), throwsArgumentError);
       });
     });
 
-    testWidgets('registerUnidentifiedUser', (WidgetTester _) async {
-      expect(plugin.registerUnidentifiedUser(), completes);
+    testWidgets('loginUnidentifiedUser', (WidgetTester _) async {
+      expect(plugin.loginUnidentifiedUser(), completes);
     });
 
     testWidgets('setBottomPadding', (WidgetTester _) async {

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -133,6 +133,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     int? signedUpAt,
     String? language,
     Map<String, dynamic>? customAttributes,
+    IntercomStatusCallback? statusCallback,
   }) async {
     Map<String, dynamic> userAttributes = {};
 
@@ -178,7 +179,8 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       'update',
       js.JsObject.jsify(userAttributes),
     ]);
-    print("User updated");
+    // send the success callback only as web doesnot support the statusCallback.
+    statusCallback?.onSuccess?.call();
   }
 
   @override

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -10,6 +10,8 @@ import 'package:uuid/uuid.dart';
 /// export the enum [IntercomVisibility]
 export 'package:intercom_flutter_platform_interface/intercom_flutter_platform_interface.dart'
     show IntercomVisibility;
+export 'package:intercom_flutter_platform_interface/intercom_status_callback.dart'
+    show IntercomStatusCallback, IntercomError;
 
 /// A web implementation of the IntercomFlutter plugin.
 class IntercomFlutterWeb extends IntercomFlutterPlatform {

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -4,6 +4,7 @@ import 'dart:js' as js;
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:intercom_flutter_platform_interface/intercom_flutter_platform_interface.dart';
+import 'package:intercom_flutter_platform_interface/intercom_status_callback.dart';
 import 'package:uuid/uuid.dart';
 
 /// export the enum [IntercomVisibility]
@@ -58,8 +59,18 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     print("user hash added");
   }
 
+  @Deprecated("use loginIdentifiedUser")
   @override
-  Future<void> registerIdentifiedUser({String? userId, String? email}) async {
+  Future<void> registerIdentifiedUser({String? userId, String? email}) {
+    return loginIdentifiedUser(userId: userId, email: email);
+  }
+
+  @override
+  Future<void> loginIdentifiedUser({
+    String? userId,
+    String? email,
+    IntercomStatusCallback? statusCallback,
+  }) async {
     if (userId?.isNotEmpty ?? false) {
       if (email?.isNotEmpty ?? false) {
         throw ArgumentError(
@@ -72,7 +83,8 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
           'user_id': userId,
         }),
       ]);
-      print("user created");
+      // send the success callback only as web doesnot support the statusCallback.
+      statusCallback?.onSuccess?.call();
     } else if (email?.isNotEmpty ?? false) {
       // register the user with email
       await js.context.callMethod('Intercom', [
@@ -81,7 +93,8 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
           'email': email,
         }),
       ]);
-      print("user created");
+      // send the success callback only as web doesnot support the statusCallback.
+      statusCallback?.onSuccess?.call();
     } else {
       throw ArgumentError(
           'An identification method must be provided as a parameter, either `userId` or `email`.');

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -101,8 +101,15 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     }
   }
 
+  @Deprecated("use loginUnidentifiedUser")
   @override
-  Future<void> registerUnidentifiedUser() async {
+  Future<void> registerUnidentifiedUser() {
+    return loginUnidentifiedUser();
+  }
+
+  @override
+  Future<void> loginUnidentifiedUser(
+      {IntercomStatusCallback? statusCallback}) async {
     // to register an unidentified user, a unique id will be created using the package uuid
     String userId = Uuid().v1();
     await js.context.callMethod('Intercom', [
@@ -111,7 +118,8 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
         'user_id': userId,
       }),
     ]);
-    print("user created");
+    // send the success callback only as web doesnot support the statusCallback.
+    statusCallback?.onSuccess?.call();
   }
 
   @override

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intercom_flutter_platform_interface: ^1.0.1
+  intercom_flutter_platform_interface: ^1.1.0
   uuid: ^3.0.1 # to get the random uuid for registerUnidentifiedUser in web
 
 dev_dependencies:

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 0.0.5
+version: 0.1.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:


### PR DESCRIPTION
Adapting the status callback support in the web platform as the platform interface changes https://github.com/v3rm0n/intercom_flutter/pull/232
Although the web does not provide any status callback so it will always send the success callback.