### PR TITLE
[7.6.1] Added extra docs for Android notifications and updated dependencies

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.6.1
+
+* Bump Intercom iOS SDK version to 14.0.2
+* Bump Intercom Android SDK version to 14.0.3
+* Added extra documentation to fix Android exception after background push notification is received ([#270](https://github.com/v3rm0n/intercom_flutter/issues/270#issuecomment-1330510979))
+
 ## 7.6.0
 
 * Bump Intercom iOS SDK version to 14.0.0 ([#269](https://github.com/v3rm0n/intercom_flutter/pull/269))

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -79,6 +79,7 @@ This plugin works in combination with the [`firebase_messaging`](https://pub.dev
 * Then, add the Firebase server key to Intercom, as described [here](https://developers.intercom.com/installing-intercom/docs/android-fcm-push-notifications#section-step-3-add-your-server-key-to-intercom-for-android-settings) (you can skip 1 and 2 as you have probably done them while configuring `firebase_messaging`)
 * Follow the steps as described [here](https://developers.intercom.com/installing-intercom/docs/ios-push-notifications) to enable push notification in iOS.
 * Starting from Android 13 you may need to ask for notification permissions (as of version 13 `firebase_messaging` should support that)
+* Make sure that your app's `MainActivity` extends `FlutterFragmentActivity` (you can check the example)
 * Ask FirebaseMessaging for the token that we need to send to Intercom, and give it to Intercom (so Intercom can send push messages to the correct device), please note that in order to receive push notifications in your iOS app, you have to send the APNS token to Intercom. The example below uses [`firebase_messaging`](https://pub.dev/packages/firebase_messaging) to get either the FCM or APNS token based on the platform:
 
 ```dart

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -5,9 +5,9 @@
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
 
-- Uses Intercom Android SDK Version `14.0.0`.
+- Uses Intercom Android SDK Version `14.0.3`.
 - The minimum Android SDK `minSdkVersion` required is 21.
-- Uses Intercom iOS SDK Version `14.0.0`.
+- Uses Intercom iOS SDK Version `14.0.2`.
 - The minimum iOS target version required is 13.
 
 ## Usage

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -2,14 +2,14 @@ group 'io.maido.intercom'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:14.0.0'
+    implementation 'io.intercom.android:intercom-sdk:14.0.3'
     implementation 'com.google.firebase:firebase-messaging:23.1.0'
 }

--- a/intercom_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/intercom_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
       android:icon="@mipmap/ic_launcher"
       android:label="intercom_example">
     <activity
-        android:name="io.flutter.embedding.android.FlutterFragmentActivity"
+        android:name=".MainActivity"
         android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
         android:hardwareAccelerated="true"
         android:exported="true"

--- a/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
       android:icon="@mipmap/ic_launcher"
       android:label="intercom_example">
     <activity
-        android:name=".MainActivity"
+        android:name="io.flutter.embedding.android.FlutterFragmentActivity"
         android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
         android:hardwareAccelerated="true"
         android:exported="true"

--- a/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MainActivity.kt
+++ b/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MainActivity.kt
@@ -1,0 +1,6 @@
+package io.maido.intercomexample
+
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity() : FlutterFragmentActivity() {
+}

--- a/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MainActivity.kt
+++ b/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MainActivity.kt
@@ -1,6 +1,0 @@
-package io.maido.intercomexample
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity() : FlutterActivity() {
-}

--- a/intercom_flutter/example/android/build.gradle
+++ b/intercom_flutter/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/intercom_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/intercom_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 17 14:27:11 IST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '~> 14.0.0'
+  s.dependency 'Intercom', '~> 14.0.2'
   s.ios.deployment_target = '13.0'
 end
 

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 7.6.0
+version: 7.6.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   intercom_flutter_platform_interface: ^1.2.1
-  uuid: ^3.0.6 # to get the random uuid for registerUnidentifiedUser in web
+  uuid: ^3.0.7 # to get the random uuid for registerUnidentifiedUser in web
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #270 

## 7.6.1

* Bump Intercom iOS SDK version to 14.0.2
* Bump Intercom Android SDK version to 14.0.3
* Added extra documentation to fix Android exception after background push notification is received ([#270](https://github.com/v3rm0n/intercom_flutter/issues/270#issuecomment-1330510979))