### PR TITLE
Update native sdk

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.6.2
+
+* Bump Intercom iOS SDK version to 14.0.6 ([#280](https://github.com/v3rm0n/intercom_flutter/pull/280))
+* Bump Intercom Android SDK version to 14.0.4 ([#280](https://github.com/v3rm0n/intercom_flutter/pull/280))
+
 ## 7.6.1
 
 * Bump Intercom iOS SDK version to 14.0.2

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -5,9 +5,9 @@
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
 
-- Uses Intercom Android SDK Version `14.0.3`.
+- Uses Intercom Android SDK Version `14.0.4`.
 - The minimum Android SDK `minSdkVersion` required is 21.
-- Uses Intercom iOS SDK Version `14.0.2`.
+- Uses Intercom iOS SDK Version `14.0.6`.
 - The minimum iOS target version required is 13.
 
 ## Usage

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:14.0.3'
+    implementation 'io.intercom.android:intercom-sdk:14.0.4'
     implementation 'com.google.firebase:firebase-messaging:23.1.0'
 }

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '~> 14.0.2'
+  s.dependency 'Intercom', '~> 14.0.6'
   s.ios.deployment_target = '13.0'
 end
 

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 7.6.1
+version: 7.6.2
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
Updated Intercom Android SDK version to [14.0.4](https://github.com/intercom/intercom-android/blob/master/CHANGELOG.md#1404).
Updated Intercom iOS SDK version to [14.0.6](https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md#1406).