### PR TITLE
Add displayHelpCenterCollections

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.6.4
+
+* Added method `displayHelpCenterCollections`.
+
 ## 7.6.3
 
 * Added method `displayMessages`.

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -111,3 +111,4 @@ Add the below script inside body tag in the index.html file located under web fo
 - [ ] isIntercomPush
 - [ ] handlePush
 - [ ] displayCarousel
+- [ ] displayHelpCenterCollections

--- a/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -148,6 +148,15 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
         Intercom.client().present(IntercomSpace.HelpCenter)
         result.success("Launched")
       }
+      "displayHelpCenterCollections" -> {
+        val collectionIds = call.argument<ArrayList<String>>("collectionIds")
+        Intercom.client().presentContent(
+          content = IntercomContent.HelpCenterCollections(
+            ids = collectionIds ?: emptyList()
+          )
+        )
+        result.success("Launched")
+      }
       "displayMessages" -> {
         Intercom.client().present(IntercomSpace.Messages)
         result.success("Launched")

--- a/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
+++ b/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
@@ -127,6 +127,15 @@ id unread;
         [Intercom presentIntercom:helpCenter];
         result(@"Presented help center");
     }
+    else if([@"displayHelpCenterCollections" isEqualToString:call.method]) {
+        NSArray *collectionIds = call.arguments[@"collectionIds"];
+        if(collectionIds != (id)[NSNull null] && collectionIds != nil) {
+            [Intercom presentContent:[IntercomContent helpCenterCollectionsWithIds:collectionIds]];
+        } else {
+            [Intercom presentContent:[IntercomContent helpCenterCollectionsWithIds:@[]]];
+        }
+        result(@"Presented help center collections");
+    }
     else if([@"displayMessages" isEqualToString:call.method]) {
         [Intercom presentIntercom:messages];
         result(@"Presented messages space");

--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -197,6 +197,17 @@ class Intercom {
     return IntercomFlutterPlatform.instance.displayHelpCenter();
   }
 
+  /// To display an Activity with your Help Center content for specific collections.
+  ///
+  /// Make sure Help Center is turned on.
+  /// If you don't have Help Center enabled in your Intercom settings the method
+  /// displayHelpCenterCollections will fail to load.
+  /// The [collectionIds] you want to display.
+  Future<void> displayHelpCenterCollections(List<String> collectionIds) {
+    return IntercomFlutterPlatform.instance
+        .displayHelpCenterCollections(collectionIds);
+  }
+
   /// To display an Activity with your Messages content.
   Future<void> displayMessages() {
     return IntercomFlutterPlatform.instance.displayMessages();

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 7.6.3+1
+version: 7.6.4
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:
@@ -9,8 +9,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intercom_flutter_platform_interface: ^1.2.2
-  intercom_flutter_web: ^0.2.2
+  intercom_flutter_platform_interface: ^1.2.3
+  intercom_flutter_web: ^0.2.3
 
 dev_dependencies:
   flutter_test:

--- a/intercom_flutter/test/intercom_flutter_test.dart
+++ b/intercom_flutter/test/intercom_flutter_test.dart
@@ -110,6 +110,13 @@ void main() {
       expectMethodCall('displayHelpCenter');
     });
 
+    test('displayHelpCenterCollections', () {
+      final collectionIds = ['collection1', 'collection2'];
+      Intercom.instance.displayHelpCenterCollections(collectionIds);
+      expectMethodCall('displayHelpCenterCollections',
+          arguments: {'collectionIds': collectionIds});
+    });
+
     test('displayMessages', () {
       Intercom.instance.displayMessages();
       expectMethodCall('displayMessages');

--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.2.3
+
+- Added method `displayHelpCenterCollections`.
+
 # 1.2.2
 
 - Added method `displayMessages`.

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -180,6 +180,17 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('displayHelpCenter() has not been implemented.');
   }
 
+  /// To display an Activity with your Help Center content for specific collections.
+  ///
+  /// Make sure Help Center is turned on.
+  /// If you don't have Help Center enabled in your Intercom settings the method
+  /// displayHelpCenterCollections will fail to load.
+  /// The [collectionIds] you want to display.
+  Future<void> displayHelpCenterCollections(List<String> collectionIds) {
+    throw UnimplementedError(
+        'displayHelpCenterCollections() has not been implemented.');
+  }
+
   /// To display an Activity with your Messages content.
   Future<void> displayMessages() {
     throw UnimplementedError('displayMessages() has not been implemented.');

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -163,6 +163,12 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
   }
 
   @override
+  Future<void> displayHelpCenterCollections(List<String> collectionIds) {
+    return _channel.invokeMethod(
+        'displayHelpCenterCollections', {'collectionIds': collectionIds});
+  }
+
+  @override
   Future<void> displayMessages() async {
     await _channel.invokeMethod('displayMessages');
   }

--- a/intercom_flutter_platform_interface/pubspec.yaml
+++ b/intercom_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_platform_interface
 description: A common platform interface for the intercom_flutter plugin.
-version: 1.2.2
+version: 1.2.3
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
+++ b/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
@@ -190,6 +190,18 @@ void main() {
       );
     });
 
+    test('displayHelpCenter', () async {
+      final collectionIds = ['collectionId1', 'collectionId2'];
+      await intercom.displayHelpCenterCollections(collectionIds);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('displayHelpCenterCollections',
+              arguments: {'collectionIds': collectionIds})
+        ],
+      );
+    });
+
     test('displayMessages', () async {
       await intercom.displayMessages();
       expect(

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.2.3
+
+- Updated dependency `intercom_flutter_platform_interface: ^1.2.3`.
+
 # 0.2.2
 
 - Added method `displayMessages`.

--- a/intercom_flutter_web/README.md
+++ b/intercom_flutter_web/README.md
@@ -26,6 +26,7 @@ But if you want to use this package as alone, first add the dependency `intercom
 - isIntercomPush
 - handlePush
 - displayCarousel
+- displayHelpCenterCollections
 
 [1]: ../intercom_flutter
 

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intercom_flutter_platform_interface: ^1.2.2
+  intercom_flutter_platform_interface: ^1.2.3
   uuid: ^3.0.7 # to get the random uuid for registerUnidentifiedUser in web
 
 dev_dependencies:


### PR DESCRIPTION
Added `displayHelpCenterCollections` method to open to specific collections

iOS: https://developers.intercom.com/installing-intercom/docs/help-center-api#present-a-filtered-help-center
Android: https://developers.intercom.com/installing-intercom/docs/help-center-api-android#present-a-filtered-help-center

I wasn't 💯 sure how to test this against our real app without pointing all the dependencies to my fork, so hopefully this is all setup ok. Lemme know if you need any changes here and thanks for putting this package together!