### PR TITLE
Initialize SDK in Android application class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Check for any formatting issues in the code.
     - name: check code format
-      run: flutter format --set-exit-if-changed .
+      run: dart format --set-exit-if-changed .
       working-directory: ${{env.source-directory}}
 
     # Run Flutter Analyzer
@@ -69,7 +69,7 @@ jobs:
 
     # Check for any formatting issues in the code.
     - name: check code format
-      run: flutter format --set-exit-if-changed .
+      run: dart format --set-exit-if-changed .
       working-directory: ${{env.source-directory}}
 
     # Run Flutter Analyzer
@@ -116,7 +116,7 @@ jobs:
 
     # Check for any formatting issues in the code.
     - name: check code format
-      run: flutter format --set-exit-if-changed .
+      run: dart format --set-exit-if-changed .
       working-directory: ${{env.source-directory}}
 
     # Run Flutter Analyzer

--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.6.8
+
+* Added way to initialize the Intercom SDK in Android application class.
+
 ## 7.6.7
 
 * Bump Intercom Android SDK version to 14.1.0

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -24,6 +24,7 @@ void main() async {
     WidgetsFlutterBinding.ensureInitialized();
     // initialize the Intercom.
     // make sure to add keys from your Intercom workspace.
+    // don't forget to set up the custom application class on Android side.
     await Intercom.instance.initialize('appIdHere', iosApiKey: 'iosKeyHere', androidApiKey: 'androidKeyHere');
     runApp(App());
 }
@@ -67,6 +68,40 @@ Enable AndroidX + Jetifier support in your android/gradle.properties file (see e
 ```
 android.useAndroidX=true
 android.enableJetifier=true
+```
+
+According to the documentation, Intercom must be initialized in the Application onCreate. So follow the below steps to achieve the same:
+- Setup custom application class if you don't have any.
+    - Create a custom `android.app.Application` class named `MyApp`.
+    - Add an `onCreate()` override. The class should look like this:
+    ```kotlin
+    import android.app.Application
+
+    class MyApp: Application() {
+
+        override fun onCreate() {
+            super.onCreate()
+        }
+    }
+    ```
+    - Open your `AndroidManifest.xml` and find the `application` tag. In it, add an `android:name` attribute, and set the value to your class' name, prefixed by a dot (.).
+    ```xml
+    <application
+      android:name=".MyApp" >
+    ```
+- Now initialize the Intercom SDK inside the `onCreate()` of custom application class according to the following:
+```kotlin
+import android.app.Application
+import io.maido.intercom.IntercomFlutterPlugin
+
+class MyApp : Application() {
+  override fun onCreate() {
+    super.onCreate()
+
+    // Add this line with your keys
+    IntercomFlutterPlugin.initSdk(this, appId = "appId", androidApiKey = "androidApiKey")
+  }
+}
 ```
 
 ### iOS

--- a/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -27,6 +27,11 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
       val unreadEventChannel = EventChannel(registrar.messenger(), "maido.io/intercom/unread")
       unreadEventChannel.setStreamHandler(IntercomFlutterPlugin())
     }
+
+    @JvmStatic
+    fun initSdk(application: Application, appId: String, androidApiKey: String) {
+      Intercom.initialize(application, apiKey = androidApiKey, appId = appId)
+    }
   }
 
   private val intercomPushClient = IntercomPushClient()

--- a/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/intercom_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
        additional functionality it is fine to subclass or reimplement
        FlutterApplication and put your custom class here. -->
   <application
+      android:name=".MyApp"
       android:icon="@mipmap/ic_launcher"
       android:label="intercom_example">
     <activity

--- a/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MyApp.kt
+++ b/intercom_flutter/example/android/app/src/main/kotlin/io/maido/intercomexample/MyApp.kt
@@ -1,0 +1,14 @@
+package io.maido.intercomexample
+
+import android.app.Application
+import io.maido.intercom.IntercomFlutterPlugin
+
+class MyApp : Application() {
+  override fun onCreate() {
+    super.onCreate()
+
+    // Initialize the Intercom SDK here also as Android requires to initialize it in the onCreate of
+    // the application.
+    IntercomFlutterPlugin.initSdk(this, appId = "appId", androidApiKey = "androidApiKey")
+  }
+}

--- a/intercom_flutter/example/lib/main.dart
+++ b/intercom_flutter/example/lib/main.dart
@@ -9,6 +9,7 @@ void main() async {
     androidApiKey: 'androidApiKey',
     iosApiKey: 'iosApiKey',
   );
+  // TODO: don't forget to set up the custom application class on Android side.
   runApp(SampleApp());
 }
 

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 7.6.7
+version: 7.6.8
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
Way to initialize the Intercom in the Android application class.
This step will remove the following exception:

```
Caused by io.intercom.android.sdk.exceptions.IntercomIntegrationException
Intercom was not initialized correctly, Intercom.initialize() needs to be called in onCreate() in your Application class.
```
