### PR TITLE
Adds documentation for using --dart-define variables to initialize th…

### DIFF
--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -104,9 +104,53 @@ class MyApp : Application() {
 }
 ```
 
-Use `--dart-define` variables to avoid hardcoding Intercom tokens:
 
-Add the following code to `build.gradle`. 
+
+### iOS
+Make sure that you have a `NSPhotoLibraryUsageDescription` entry in your `Info.plist`.
+
+### Push notifications setup
+This plugin works in combination with the [`firebase_messaging`](https://pub.dev/packages/firebase_messaging) plugin to receive Push Notifications. To set this up:
+
+* First, implement [`firebase_messaging`](https://pub.dev/packages/firebase_messaging)
+* Then, add the Firebase server key to Intercom, as described [here](https://developers.intercom.com/installing-intercom/docs/android-fcm-push-notifications#section-step-3-add-your-server-key-to-intercom-for-android-settings) (you can skip 1 and 2 as you have probably done them while configuring `firebase_messaging`)
+* Follow the steps as described [here](https://developers.intercom.com/installing-intercom/docs/ios-push-notifications) to enable push notification in iOS.
+* Starting from Android 13 you may need to ask for notification permissions (as of version 13 `firebase_messaging` should support that)
+* Ask FirebaseMessaging for the token that we need to send to Intercom, and give it to Intercom (so Intercom can send push messages to the correct device), please note that in order to receive push notifications in your iOS app, you have to send the APNS token to Intercom. The example below uses [`firebase_messaging`](https://pub.dev/packages/firebase_messaging) to get either the FCM or APNS token based on the platform:
+
+```dart
+final firebaseMessaging = FirebaseMessaging.instance;
+final intercomToken = Platform.isIOS ? await firebaseMessaging.getAPNSToken() : await firebaseMessaging.getToken();
+
+Intercom.instance.sendTokenToIntercom(intercomToken);
+```
+
+Now, if either Firebase direct (e.g. by your own backend server) or Intercom sends you a message, it will be delivered to your app.
+
+### Web
+Add the below script inside body tag in the index.html file located under web folder
+```html
+<script>
+    window.intercomSettings = {
+        hide_default_launcher: true, // set this to false, if you want to show the default launcher
+    };
+    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+</script>
+```
+
+### Using Intercom keys with --dart-define
+
+This is useful if you want to avoid hardcoding your keys inside your app.
+
+You can `run` or `build` your app like this: 
+
+```shell
+flutter run ./lib/main.dart \ 
+    --dart-define APP_ID=yourAppId \
+    --dart-define ANDROID_TOKEN=yourAndroidToken
+```
+
+Start by adding the following code to `build.gradle`.
 ```
 def dartEnvironmentVariables = []
 if (project.hasProperty('dart-defines')) {
@@ -148,37 +192,6 @@ class MyApp : Application() {
 }
 ```
 
-### iOS
-Make sure that you have a `NSPhotoLibraryUsageDescription` entry in your `Info.plist`.
-
-### Push notifications setup
-This plugin works in combination with the [`firebase_messaging`](https://pub.dev/packages/firebase_messaging) plugin to receive Push Notifications. To set this up:
-
-* First, implement [`firebase_messaging`](https://pub.dev/packages/firebase_messaging)
-* Then, add the Firebase server key to Intercom, as described [here](https://developers.intercom.com/installing-intercom/docs/android-fcm-push-notifications#section-step-3-add-your-server-key-to-intercom-for-android-settings) (you can skip 1 and 2 as you have probably done them while configuring `firebase_messaging`)
-* Follow the steps as described [here](https://developers.intercom.com/installing-intercom/docs/ios-push-notifications) to enable push notification in iOS.
-* Starting from Android 13 you may need to ask for notification permissions (as of version 13 `firebase_messaging` should support that)
-* Ask FirebaseMessaging for the token that we need to send to Intercom, and give it to Intercom (so Intercom can send push messages to the correct device), please note that in order to receive push notifications in your iOS app, you have to send the APNS token to Intercom. The example below uses [`firebase_messaging`](https://pub.dev/packages/firebase_messaging) to get either the FCM or APNS token based on the platform:
-
-```dart
-final firebaseMessaging = FirebaseMessaging.instance;
-final intercomToken = Platform.isIOS ? await firebaseMessaging.getAPNSToken() : await firebaseMessaging.getToken();
-
-Intercom.instance.sendTokenToIntercom(intercomToken);
-```
-
-Now, if either Firebase direct (e.g. by your own backend server) or Intercom sends you a message, it will be delivered to your app.
-
-### Web
-Add the below script inside body tag in the index.html file located under web folder
-```html
-<script>
-    window.intercomSettings = {
-        hide_default_launcher: true, // set this to false, if you want to show the default launcher
-    };
-    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
-</script>
-```
 #### Following functions are not yet supported on Web:
 
 - [ ] unreadConversationCount

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -104,8 +104,6 @@ class MyApp : Application() {
 }
 ```
 
-
-
 ### iOS
 Make sure that you have a `NSPhotoLibraryUsageDescription` entry in your `Info.plist`.
 

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -104,6 +104,50 @@ class MyApp : Application() {
 }
 ```
 
+Use `--dart-define` variables to avoid hardcoding Intercom tokens:
+
+Add the following code to `build.gradle`. 
+```
+def dartEnvironmentVariables = []
+if (project.hasProperty('dart-defines')) {
+  dartEnvironmentVariables = project.property('dart-defines')
+      .split(',')
+      .collectEntries { entry ->
+        def pair = new String(entry.decodeBase64(), 'UTF-8').split('=')
+        [(pair.first()): pair.last()]
+      }
+}
+```
+
+Place dartEnvironmentVariables inside the BuildConfig
+
+```
+defaultConfig {
+    ...
+
+    buildConfigField 'String', 'APP_ID', "\"${dartEnvironmentVariables.APP_ID}\""
+    buildConfigField 'String', 'ANDROID_TOKEN', "\"${dartEnvironmentVariables.ANDROID_TOKEN}\""
+}
+```
+
+Read the BuildConfig fields
+
+```kotlin
+import android.app.Application
+import io.maido.intercom.IntercomFlutterPlugin
+
+class MyApp : Application() {
+  override fun onCreate() {
+    super.onCreate()
+
+    // Add this line with your keys
+    IntercomFlutterPlugin.initSdk(this, 
+      appId = BuildConfig.APP_ID, 
+      androidApiKey = BuildConfig.ANDROID_TOKEN)
+  }
+}
+```
+
 ### iOS
 Make sure that you have a `NSPhotoLibraryUsageDescription` entry in your `Info.plist`.
 


### PR DESCRIPTION
Adds documentation for using `--dart-define` variables to initialise the IntercomFlutterPlugin SDK on Android.

This is a solution we used in our app to avoid hardcoding Intercom tokens. We believe it could be helpful to others trying to solve the same problem.

Cheers!