### PR TITLE
Add public api to present a conversation with conversation id

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.8.4
+
+* Bump Intercom iOS SDK version to 15.1.4
+* Bump Intercom Android SDK version to 15.1.6
+* Implemented `displayConversation` for all platforms.
+
 ## 7.8.3
 
 * Bump Intercom iOS SDK version to 15.1.3

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:15.1.4'
+    implementation 'io.intercom.android:intercom-sdk:15.1.6'
     implementation 'com.google.firebase:firebase-messaging:23.1.2'
 }

--- a/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -251,6 +251,13 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
           result.success("displaying survey $surveyId")
         }
       }
+      "displayConversation" -> {
+        val conversationId = call.argument<String>("conversationId")
+        if (conversationId != null) {
+          Intercom.client().presentContent(IntercomContent.Conversation(conversationId))
+          result.success("displaying conversation $conversationId")
+        }
+      }
       else -> result.notImplemented()
     }
   }

--- a/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
+++ b/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
@@ -218,6 +218,12 @@ id unread;
         NSDictionary *message = call.arguments[@"message"];
         [Intercom handleIntercomPushNotification:message];
         result(@"handle push");
+    } else if([@"displayConversation" isEqualToString:call.method]) {
+        NSString *conversationId = call.arguments[@"conversationId"];
+        if(conversationId != (id)[NSNull null] && conversationId != nil) {
+            [Intercom presentContent:[IntercomContent conversationWithId:conversationId]];
+            result(@"displaying conversation");
+        }
     }
     else {
         result(FlutterMethodNotImplemented);

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,6 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '15.1.3'
+  s.dependency 'Intercom', '15.1.4'
   s.ios.deployment_target = '13.0'
 end

--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -281,4 +281,9 @@ class Intercom {
   Future<void> displaySurvey(String surveyId) {
     return IntercomFlutterPlatform.instance.displaySurvey(surveyId);
   }
+
+  /// To display a Conversation, pass in a [conversationId] from your Intercom workspace.
+  Future<void> displayConversation(String conversationId) {
+    return IntercomFlutterPlatform.instance.displayConversation(conversationId);
+  }
 }

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 7.8.3
+version: 7.8.4
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:
@@ -9,8 +9,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intercom_flutter_platform_interface: ^1.3.0
-  intercom_flutter_web: ^0.3.1
+  intercom_flutter_platform_interface: ^1.3.1
+  intercom_flutter_web: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/intercom_flutter/test/intercom_flutter_test.dart
+++ b/intercom_flutter/test/intercom_flutter_test.dart
@@ -265,4 +265,12 @@ void main() {
       'surveyId': testSurveyId,
     });
   });
+
+  test('displayConversation', () async {
+    final String testConversationId = "123456";
+    await Intercom.instance.displayConversation(testConversationId);
+    expectMethodCall('displayConversation', arguments: {
+      'conversationId': testConversationId,
+    });
+  });
 }

--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+* Added method `displayConversation`
+
 ## 1.3.0
 
 * Update minimum Dart version to Dart 3.

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -273,4 +273,9 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   Future<void> displaySurvey(String surveyId) {
     throw UnimplementedError('displaySurvey() has not been implemented.');
   }
+
+  /// To display a Conversation, pass in a [conversationId] from your Intercom workspace.
+  Future<void> displayConversation(String conversationId) {
+    throw UnimplementedError('displayConversation() has not been implemented.');
+  }
 }

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -237,9 +237,10 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     await _channel.invokeMethod('displaySurvey', {'surveyId': surveyId});
   }
 
-   @override
+  @override
   Future<void> displayConversation(String conversationId) async {
-    await _channel.invokeMethod('displayConversation', {'conversationId': conversationId});
+    await _channel.invokeMethod(
+        'displayConversation', {'conversationId': conversationId});
   }
 
   /// Convert the [PlatformException] details to [IntercomError].

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -237,6 +237,11 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     await _channel.invokeMethod('displaySurvey', {'surveyId': surveyId});
   }
 
+   @override
+  Future<void> displayConversation(String conversationId) async {
+    await _channel.invokeMethod('displayConversation', {'conversationId': conversationId});
+  }
+
   /// Convert the [PlatformException] details to [IntercomError].
   /// From the Platform side if the intercom operation failed then error details
   /// will be sent as details in [PlatformException].

--- a/intercom_flutter_platform_interface/pubspec.yaml
+++ b/intercom_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_platform_interface
 description: A common platform interface for the intercom_flutter plugin.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
+++ b/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
@@ -410,6 +410,19 @@ void main() {
         ],
       );
     });
+
+    String testConversationId = "123456";
+    test('displayConversation', () async {
+      await intercom.displayConversation(testConversationId);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('displayConversation', arguments: {
+            'conversationId': testConversationId,
+          })
+        ],
+      );
+    });
   });
 }
 

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+* Implemented method `displayConversation`.
+
 ## 0.3.1
 
 * Implemented method `displayHelpCenter`.

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -268,6 +268,12 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     await js.context.callMethod('Intercom', ['startSurvey', surveyId]);
   }
 
+  @override
+  Future<void> displayConversation(String conversationId) async {
+    await js.context
+        .callMethod('Intercom', ['conversation_id', conversationId]);
+  }
+
   /// get the [window.IntercomSettings]
   js.JsObject getIntercomSettings() {
     if (js.context.hasProperty('intercomSettings')) {

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intercom_flutter_platform_interface: ^1.3.0
+  intercom_flutter_platform_interface: ^1.3.1
   uuid: ^3.0.7 # to get the random uuid for registerUnidentifiedUser in web
 
 dev_dependencies:


### PR DESCRIPTION
- Bumps both iOS and Android intercom sdks to the latest
- Adds `displayConversation(String conversationId)` to enable presenting conversation programmatically 