### PR TITLE
Add `displayConversation` to platform interface

### DIFF
--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+* Added method `displayConversation`
+
 ## 1.3.0
 
 * Update minimum Dart version to Dart 3.

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -273,4 +273,9 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   Future<void> displaySurvey(String surveyId) {
     throw UnimplementedError('displaySurvey() has not been implemented.');
   }
+
+  /// To display a Conversation, pass in a [conversationId] from your Intercom workspace.
+  Future<void> displayConversation(String conversationId) {
+    throw UnimplementedError('displayConversation() has not been implemented.');
+  }
 }

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -237,6 +237,12 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     await _channel.invokeMethod('displaySurvey', {'surveyId': surveyId});
   }
 
+  @override
+  Future<void> displayConversation(String conversationId) async {
+    await _channel.invokeMethod(
+        'displayConversation', {'conversationId': conversationId});
+  }
+
   /// Convert the [PlatformException] details to [IntercomError].
   /// From the Platform side if the intercom operation failed then error details
   /// will be sent as details in [PlatformException].

--- a/intercom_flutter_platform_interface/pubspec.yaml
+++ b/intercom_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_platform_interface
 description: A common platform interface for the intercom_flutter plugin.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
+++ b/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
@@ -410,6 +410,19 @@ void main() {
         ],
       );
     });
+
+    String testConversationId = "123456";
+    test('displayConversation', () async {
+      await intercom.displayConversation(testConversationId);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('displayConversation', arguments: {
+            'conversationId': testConversationId,
+          })
+        ],
+      );
+    });
   });
 }
 


### PR DESCRIPTION
- Adds a new method `displayConversation` to the platform interface.
- Bumps version to 1.3.1