### PR TITLE
Add `displayTickets` interface

### DIFF
--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.3.2
+
+* Added method `displayTickets`
 
 ## 1.3.1
 

--- a/intercom_flutter_platform_interface/CHANGELOG.md
+++ b/intercom_flutter_platform_interface/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ## 1.3.2
 
 * Added method `displayTickets`

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -279,8 +279,8 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('displayConversation() has not been implemented.');
   }
 
-  /// To display an Activity with your Messages content.
+  /// To display an activity with all your tickets.
   Future<void> displayTickets() {
-    throw UnimplementedError('displayMessages() has not been implemented.');
+    throw UnimplementedError('displayTickets() has not been implemented.');
   }
 }

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -278,4 +278,9 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   Future<void> displayConversation(String conversationId) {
     throw UnimplementedError('displayConversation() has not been implemented.');
   }
+
+  /// To display an Activity with your Messages content.
+  Future<void> displayTickets() {
+    throw UnimplementedError('displayMessages() has not been implemented.');
+  }
 }

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -243,6 +243,11 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
         'displayConversation', {'conversationId': conversationId});
   }
 
+  @override
+  Future<void> displayTickets() async {
+    await _channel.invokeMethod('displayTickets');
+  }
+
   /// Convert the [PlatformException] details to [IntercomError].
   /// From the Platform side if the intercom operation failed then error details
   /// will be sent as details in [PlatformException].

--- a/intercom_flutter_platform_interface/pubspec.yaml
+++ b/intercom_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_platform_interface
 description: A common platform interface for the intercom_flutter plugin.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
+++ b/intercom_flutter_platform_interface/test/method_channel_intercom_flutter_test.dart
@@ -423,6 +423,14 @@ void main() {
         ],
       );
     });
+
+    test('displayTickets', () async {
+      await intercom.displayTickets();
+      expect(
+        log,
+        <Matcher>[isMethodCall('displayTickets', arguments: null)],
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Intercom introduced tickets space recently. This would setup a public method with which end users will be able to present tickets space.

 - Adds `displayTickets` interface
 - Bumps version