### PR TITLE
Downgrade collection to 1.17.2

### DIFF
--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  collection: ^1.18.0
+  collection: ^1.17.2
 
 flutter:
   plugin:


### PR DESCRIPTION
```
Note: collection is pinned to version 1.17.2 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because intercom_flutter depends on flutter_test from sdk which depends on
  collection 1.17.2, collection 1.17.2 is required.
So, because intercom_flutter depends on collection ^1.18.0, version solving
  failed.
```

```
[✓] Flutter (Channel stable, 3.13.6, on macOS 12.6.7 21G651 darwin-x64, locale
    en-US)
[✓] Android toolchain - develop for Android devices (Android SDK version 30.0.3)
[✓] Xcode - develop for iOS and macOS (Xcode 14.2)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2022.1)
[✓] IntelliJ IDEA Community Edition (version 2019.3.3)
[✓] VS Code (version 1.84.2)
[✓] Connected device (2 available)
[✓] Network resources
```