### PR TITLE
Migrate to js_interop

### DIFF
--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+* Migrated to js_interop to be compatible with WASM.
+
 ## 1.0.2
 
 * Automatically Injected Intercom script, if it is not added.

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -73,7 +73,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     globalContext.callMethod(
       'Intercom'.toJS,
       'update'.toJS,
-      {'user_hash': userHash}.toJSBox,
+      {'user_hash': userHash}.jsify(),
     );
     print("user hash added");
   }
@@ -93,7 +93,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       globalContext.callMethod(
         'Intercom'.toJS,
         'update'.toJS,
-        {'user_id': userId}.toJSBox,
+        {'user_id': userId}.jsify(),
       );
       // send the success callback only as web does not support the statusCallback.
       statusCallback?.onSuccess?.call();
@@ -102,7 +102,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       globalContext.callMethod(
         'Intercom'.toJS,
         'update'.toJS,
-        {'email': email}.toJSBox,
+        {'email': email}.jsify(),
       );
       // send the success callback only as web does not support the statusCallback.
       statusCallback?.onSuccess?.call();
@@ -120,7 +120,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     globalContext.callMethod(
       'Intercom'.toJS,
       'update'.toJS,
-      {'user_id': userId}.toJSBox,
+      {'user_id': userId}.jsify(),
     );
     // send the success callback only as web does not support the statusCallback.
     statusCallback?.onSuccess?.call();
@@ -180,7 +180,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     }
 
     globalContext.callMethod(
-        'Intercom'.toJS, 'update'.toJS, userAttributes.toJSBox);
+        'Intercom'.toJS, 'update'.toJS, userAttributes.jsify());
     // send the success callback only as web does not support the statusCallback.
     statusCallback?.onSuccess?.call();
   }
@@ -191,7 +191,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       'Intercom'.toJS,
       'trackEvent'.toJS,
       name.toJS,
-      metaData != null ? metaData.toJSBox : null,
+      metaData != null ? metaData.jsify() : null,
     );
 
     print("Logged event");

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   intercom_flutter_platform_interface: ^2.0.0
   uuid: ^4.2.1 # to get the random uuid for loginUnidentifiedUser in web
+  web: '>=0.3.0 <0.6.0'
 
 dev_dependencies:
   flutter_test:
@@ -24,5 +25,5 @@ dev_dependencies:
   mockito: ^5.4.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
   flutter: ">=3.10.0"


### PR DESCRIPTION
- Migrate usage of `dart:html` to `package:web`
- Migrate usage of `dart:js`, `dart:js_util`, and `package:js` to `dart:js_interop`

See https://dart.dev/interop/js-interop/package-web and https://dart.dev/interop/js-interop/past-js-interop

Fixes #406 