### PR TITLE
Use Map instead of JSObject to update window.intercomSettings

### DIFF
--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+* Updated window.intercomSettings as Map instead of JSObject.
+
 ## 1.1.0
 
 * Migrated to js_interop to be compatible with WASM.

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -51,7 +51,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       web.HTMLScriptElement script =
           web.document.createElement("script") as web.HTMLScriptElement;
       script.text = """
-          window.intercomSettings = ${updateIntercomSettings('app_id', "'$appId'").dartify()};
+          window.intercomSettings = ${updateIntercomSettings('app_id', "'$appId'")};
           (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + '$appId';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();  
       """;
       if (web.document.body != null) {
@@ -62,7 +62,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       globalContext.callMethod(
         'Intercom'.toJS,
         'boot'.toJS,
-        updateIntercomSettings('app_id', appId),
+        updateIntercomSettings('app_id', appId).jsify(),
       );
     }
     print("initialized");
@@ -205,7 +205,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       updateIntercomSettings(
         'hide_default_launcher',
         visibility == IntercomVisibility.visible ? false : true,
-      ),
+      ).jsify(),
     );
 
     print("Showing launcher: $visibility");
@@ -256,7 +256,7 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
       updateIntercomSettings(
         'vertical_padding',
         padding,
-      ),
+      ).jsify(),
     );
 
     print("Bottom padding set");
@@ -286,20 +286,28 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     print("Launched Tickets space");
   }
 
-  /// get the [window.IntercomSettings]
-  JSObject getIntercomSettings() {
+  /// get the [window.intercomSettings]
+  Map<dynamic, dynamic> getIntercomSettings() {
     if (globalContext.hasProperty('intercomSettings'.toJS).toDart) {
-      return globalContext.getProperty('intercomSettings'.toJS) as JSObject;
+      var settings =
+          globalContext.getProperty('intercomSettings'.toJS).dartify();
+      // settings are of type LinkedMap<Object?, Object?>
+      return settings as Map;
     }
 
-    return JSObject();
+    return {};
   }
 
-  /// add/update property to [window.IntercomSettings]
+  /// add/update property to [window.intercomSettings]
   /// and returns the updated object
-  JSObject updateIntercomSettings(String key, dynamic value) {
+  Map<dynamic, dynamic> updateIntercomSettings(String key, dynamic value) {
     var intercomSettings = getIntercomSettings();
     intercomSettings[key] = value;
+
+    // Update the [window.intercomSettings]
+    globalContext.setProperty(
+        "intercomSettings".toJS, intercomSettings.jsify());
+
     return intercomSettings;
   }
 }

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:


### PR DESCRIPTION
Using the JSObject was working in debug mode. But in the release mode it throws the following error during build.

```
The compiler crashed: Reference to dart:_js_types::JSObject::@methods::|staticInteropFactoryStub is not bound to an AST node. A procedure was expected
#0      Reference.asProcedure (package:kernel/canonical_name.dart:546:7)
#1      StaticInvocation.target (package:kernel/ast.dart:6470:43)
#2      StaticInteropClassEraser.visitStaticInvocation (package:_js_interop_checks/src/transformations/static_interop_class_eraser.dart:308:28)
#3      StaticInvocation.accept (package:kernel/ast.dart:6485:44)
#4      Transformer.transform (package:kernel/visitor.dart:1773:17)
#5      ReturnStatement.transformChildren (package:kernel/ast.dart:10069:22)
#6      Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#7      TreeVisitorDefault.defaultStatement (package:kernel/visitor.dart:622:41)
#8      StatementVisitorDefaultMixin.visitReturnStatement (package:kernel/visitor.dart:377:51)
#9      ReturnStatement.accept (package:kernel/ast.dart:10055:43)
#10     Transformer.transform (package:kernel/visitor.dart:1773:17)
#11     Transformer.transformList (package:kernel/visitor.dart:1790:18)
#12     Block.transformChildren (package:kernel/ast.dart:9113:7)
#13     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#14     TreeVisitorDefault.defaultStatement (package:kernel/visitor.dart:622:41)
#15     StatementVisitorDefaultMixin.visitBlock (package:kernel/visitor.dart:345:31)
#16     Block.accept (package:kernel/ast.dart:9101:43)
#17     Transformer.transform (package:kernel/visitor.dart:1773:17)
#18     FunctionNode.transformChildren (package:kernel/ast.dart:3829:16)
#19     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#20     TreeVisitorDefaultMixin.visitFunctionNode (package:kernel/visitor.dart:577:45)
#21     FunctionNode.accept (package:kernel/ast.dart:3796:38)
#22     Transformer.transform (package:kernel/visitor.dart:1773:17)
#23     Procedure.transformChildren (package:kernel/ast.dart:3186:18)
#24     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#25     TreeVisitorDefault.defaultMember (package:kernel/visitor.dart:626:35)
#26     MemberVisitorDefaultMixin.visitProcedure (package:kernel/visitor.dart:411:39)
#27     StaticInteropClassEraser.visitProcedure (package:_js_interop_checks/src/transformations/static_interop_class_eraser.dart:287:18)
#28     Procedure.accept (package:kernel/ast.dart:3167:40)
#29     Transformer.transform (package:kernel/visitor.dart:1773:17)
#30     Transformer.transformList (package:kernel/visitor.dart:1790:18)
#31     Class.transformChildren (package:kernel/ast.dart:1498:7)
#32     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#33     TreeVisitorDefaultMixin.visitClass (package:kernel/visitor.dart:556:31)
#34     Class.accept (package:kernel/ast.dart:1444:38)
#35     Transformer.transform (package:kernel/visitor.dart:1773:17)
#36     Transformer.transformList (package:kernel/visitor.dart:1790:18)
#37     Library.transformChildren (package:kernel/ast.dart:605:7)
#38     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#39     TreeVisitorDefaultMixin.visitLibrary (package:kernel/visitor.dart:565:35)
#40     StaticInteropClassEraser.visitLibrary (package:_js_interop_checks/src/transformations/static_interop_class_eraser.dart:227:18)
#41     Library.accept (package:kernel/ast.dart:581:38)
#42     Transformer.transform (package:kernel/visitor.dart:1773:17)
#43     Transformer.transformList (package:kernel/visitor.dart:1790:18)
#44     Component.transformChildren (package:kernel/ast.dart:14443:7)
#45     Transformer.defaultTreeNode (package:kernel/visitor.dart:1807:10)
#46     TreeVisitorDefaultMixin.visitComponent (package:kernel/visitor.dart:600:39)
#47     _doTransformsOnKernelLoad (package:compiler/src/phase/load_kernel.dart:140:8)
#48     _loadFromKernel (package:compiler/src/phase/load_kernel.dart:207:3)
<asynchronous suspension>
#49     run (package:compiler/src/phase/load_kernel.dart:409:9)
<asynchronous suspension>
#50     Compiler.loadKernel (package:compiler/src/compiler.dart:395:9)
<asynchronous suspension>
#51     Compiler.produceKernel (package:compiler/src/compiler.dart:402:36)
<asynchronous suspension>
#52     Compiler.runSequentialPhases (package:compiler/src/compiler.dart:718:20)
<asynchronous suspension>
#53     Compiler.runInternal.<anonymous closure> (package:compiler/src/compiler.dart:318:7)
<asynchronous suspension>
#54     Compiler.runInternal (package:compiler/src/compiler.dart:317:5)
<asynchronous suspension>
#55     Compiler.run.<anonymous closure> (package:compiler/src/compiler.dart:238:11)
<asynchronous suspension>
#56     compile.<anonymous closure> (package:compiler/compiler_api.dart:252:30)
<asynchronous suspension>
#57     compile.compilationDone (package:compiler/src/dart2js.dart:745:3)
<asynchronous suspension>
#58     main (package:compiler/src/dart2js.dart:1265:3)
<asynchronous suspension>
```

This is the documentation of JSObject under js_interop (Flutter 3.16.9)
```
/// This is the supertype of all JS objects, but not other JS types, like
/// primitives. This is the only allowed `on` type for inline classes written by
/// users to model JS interop objects. See https://dart.dev/web/js-interop for
/// more details on how to use JS interop.
```