### PR TITLE
Update Android SDK version 15.6.3

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.1.1
+
+* Bump Intercom Android SDK version to 15.6.3
+
 ## 8.1.0
 
 * Bump Intercom iOS SDK version to 16.5.6

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -5,7 +5,7 @@
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
 
-- Uses Intercom Android SDK Version `15.6.2`.
+- Uses Intercom Android SDK Version `15.6.3`.
 - The minimum Android SDK `minSdk` required is 21.
 - The compile Android SDK `compileSdk` required is 34.
 - Uses Intercom iOS SDK Version `16.5.6`.

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -50,6 +50,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:15.6.2'
+    implementation 'io.intercom.android:intercom-sdk:15.6.3'
     implementation 'com.google.firebase:firebase-messaging:23.3.1'
 }

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 8.1.0
+version: 8.1.1
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
Hi! Thank you for your work.

I see the trending issue in my application on Android in Crashlytics after updating Intercom to 15.6.2 on devices below Android 7.

This issue is reported on official support track several times: https://community.intercom.com/mobile-sdks-24/intercom-sdk-15-6-2-crash-on-android-5-sdk-21-6734

I see the new Android Intercom SDK with this fix: https://github.com/intercom/intercom-android/blob/master/CHANGELOG.md#1563