### PR TITLE
Update intercom-android 15.8.0 and intercom-ios 17.0.0

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.0.0
+* Bump Intercom Android SDK version to 15.8.0
+* Bump Intercom iOS SDK version to 17.0.0 (requires minimum iOS 15)
+
 ## 8.1.3
 
 * Bump Intercom Android SDK version to 15.7.1

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -5,11 +5,11 @@
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
 
-- Uses Intercom Android SDK Version `15.7.1`.
+- Uses Intercom Android SDK Version `15.8.0`.
 - The minimum Android SDK `minSdk` required is 21.
 - The compile Android SDK `compileSdk` required is 34.
-- Uses Intercom iOS SDK Version `16.6.1`.
-- The minimum iOS target version required is 13.
+- Uses Intercom iOS SDK Version `17.0.0`.
+- The minimum iOS target version required is 15.
 - The Xcode version required is 15.
 
 ## Usage

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -50,6 +50,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:15.7.1'
+    implementation 'io.intercom.android:intercom-sdk:15.8.0'
     implementation 'com.google.firebase:firebase-messaging:23.3.1'
 }

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'intercom_flutter'
-  s.version          = '7.5.0'
+  s.version          = '9.0.0'
   s.summary          = 'Intercom integration for Flutter'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -17,6 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '16.6.1'
-  s.ios.deployment_target = '13.0'
+  s.dependency 'Intercom', '17.0.0'
+  s.ios.deployment_target = '15.0'
 end

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 8.1.3
+version: 9.0.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
Required to support Apple's privacy manifest requirements. https://developer.apple.com/support/third-party-SDK-requirements/

Intercom iOS 17.0.0 has a fix. https://github.com/intercom/intercom-ios/releases