### PR TITLE
Update intercom-android 15.10.2 and intercom-ios 17.3.0

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.0.9
+
+* Bump Intercom Android SDK version to 15.10.2
+* Bump Intercom iOS SDK version to 17.3.0
+
 ## 9.0.8
 
 * Bump Intercom Android SDK version to 15.10.1

--- a/intercom_flutter/README.md
+++ b/intercom_flutter/README.md
@@ -5,10 +5,10 @@
 
 Flutter wrapper for Intercom [Android](https://github.com/intercom/intercom-android), [iOS](https://github.com/intercom/intercom-ios), and [Web](https://developers.intercom.com/installing-intercom/docs/basic-javascript) projects.
 
-- Uses Intercom Android SDK Version `15.10.1`.
+- Uses Intercom Android SDK Version `15.10.2`.
 - The minimum Android SDK `minSdk` required is 21.
 - The compile Android SDK `compileSdk` required is 34.
-- Uses Intercom iOS SDK Version `17.2.1`.
+- Uses Intercom iOS SDK Version `17.3.0`.
 - The minimum iOS target version required is 15.
 - The Xcode version required is 15.
 

--- a/intercom_flutter/android/build.gradle
+++ b/intercom_flutter/android/build.gradle
@@ -50,6 +50,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'io.intercom.android:intercom-sdk:15.10.1'
+    implementation 'io.intercom.android:intercom-sdk:15.10.2'
     implementation 'com.google.firebase:firebase-messaging:23.3.1'
 }

--- a/intercom_flutter/ios/intercom_flutter.podspec
+++ b/intercom_flutter/ios/intercom_flutter.podspec
@@ -17,6 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '17.2.1'
+  s.dependency 'Intercom', '17.3.0'
   s.ios.deployment_target = '15.0'
 end

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 9.0.8
+version: 9.0.9
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
- Bump Intercom Android SDK version to 15.10.2
- Bump Intercom iOS SDK version to 17.3.0