### PR TITLE
Fixed a dependency constraint issue with the package:web

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 9.0.10
+
 * Bump `intercom_flutter_web` to `1.1.2` supporting `web` `^1.0.0`.
 
 ## 9.0.9

--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.0.10
+* Bump `intercom_flutter_web` to `1.1.2` supporting `web` `^1.0.0`.
+
 ## 9.0.9
 
 * Bump Intercom Android SDK version to 15.10.2

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 9.0.9
+version: 9.0.10
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:
@@ -10,7 +10,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   intercom_flutter_platform_interface: ^2.0.0
-  intercom_flutter_web: ^1.1.0
+  intercom_flutter_web: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.1.2
+
 * Bump `web` to `^1.0.0`
 
 ## 1.1.1

--- a/intercom_flutter_web/CHANGELOG.md
+++ b/intercom_flutter_web/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+* Bump `web` to `^1.0.0`
+
 ## 1.1.1
 
 * Updated window.intercomSettings as Map instead of JSObject.

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   intercom_flutter_platform_interface: ^2.0.0
   uuid: ^4.2.1 # to get the random uuid for loginUnidentifiedUser in web
-  web: '>=0.3.0 <0.6.0'
+  web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/intercom_flutter_web/pubspec.yaml
+++ b/intercom_flutter_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intercom_flutter_web
 description: Web platform implementation of intercom_flutter
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 flutter:


### PR DESCRIPTION
Fixes #454 
Fixes the issue with dependency constraint of the `package:web` since a newer version has been released.

I've ran the `intergration_tests` in the web package folder and all of them passed. It seems that no other changes are needed.